### PR TITLE
Add rebar conf to allow build from Erlang project

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,8 @@
+{deps, [{rebar_elixir_plugin, ".*", {git, "https://github.com/yrashk/rebar_elixir_plugin.git"}}]}.
+{plugins, [rebar_elixir_compiler, rebar_exunit] }.
+
+%% Allow compilation of eqc_ex as rebar dependency
+{lib_dirs, [
+  "../../deps/elixir/lib",
+  "deps/elixir/lib"
+]}.


### PR DESCRIPTION
This makes it possible to add eqc_ex as dependency of an Erlang project like processone/ejabberd

See mremond/ejabberd@fe97a96 to check integration.
