### PR TITLE
fix Mix.Utils.read_path in Elixir 1.10

### DIFF
--- a/lib/mix/tasks/eqc_install.ex
+++ b/lib/mix/tasks/eqc_install.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Eqc.Install do
     # Need to fix this in Elixir.
     
     Mix.shell.info [:green, "* fetching ", :reset, src]
-    case Mix.Utils.read_path(src, []) do
+    case Mix.Utils.read_path(src, unsafe_uri: true) do
       {:ok, binary} ->
         unpack(binary, dst, opts)                                      
                                         


### PR DESCRIPTION
Without this, an error will be raised:
```
** (Mix) fetching from URIs require a checksum to be given

Could not fetch QuickCheck at:
   http://quviq.com/downloads/eqcmini.zip
```
See https://github.com/elixir-lang/elixir/blob/a94911881d4c0424fe3eaf154aa0d87cc5163b51/lib/mix/lib/mix/utils.ex#L534 for details.